### PR TITLE
Allows for certain jobs to not get emails or accounts

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -37,6 +37,9 @@
 
 	var/hud_icon						  //icon used for Sec HUD overlay
 
+	var/has_email = FALSE				  //Does this job get an email account?
+	var/has_account = TRUE				  //Does this job have a bank account?
+
 /datum/job/New()
 	..()
 	if(prob(100-availablity_chance))	//Close positions, blah blah.

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -358,7 +358,8 @@ var/global/datum/controller/occupations/job_master
 		if(job)
 
 			//Equip job items.
-			job.setup_account(H)
+			if(job.has_account)
+				job.setup_account(H)
 			job.equip(H, H.mind ? H.mind.role_alt_title : "", H.char_branch, H.char_rank)
 			job.apply_fingerprints(H)
 
@@ -473,31 +474,32 @@ var/global/datum/controller/occupations/job_master
 			to_chat(H, "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>")
 
 
-		// EMAIL GENERATION
-		var/domain
-		if(H.char_branch && H.char_branch.email_domain)
-			domain = H.char_branch.email_domain
-		else
-			domain = "freemail.nt"
-		var/sanitized_name = sanitize(replacetext(replacetext(lowertext(H.real_name), " ", "."), "'", ""))
-		var/complete_login = "[sanitized_name]@[domain]"
+		if(job.has_email)//Don't generate an email if they don't have one.
+			// EMAIL GENERATION
+			var/domain
+			if(H.char_branch && H.char_branch.email_domain)
+				domain = H.char_branch.email_domain
+			else
+				domain = "freemail.nt"
+			var/sanitized_name = sanitize(replacetext(replacetext(lowertext(H.real_name), " ", "."), "'", ""))
+			var/complete_login = "[sanitized_name]@[domain]"
 
-		// It is VERY unlikely that we'll have two players, in the same round, with the same name and branch, but still, this is here.
-		// If such conflict is encountered, a random number will be appended to the email address. If this fails too, no email account will be created.
-		if(ntnet_global.does_email_exist(complete_login))
-			complete_login = "[sanitized_name][random_id(/datum/computer_file/data/email_account/, 100, 999)]@[domain]"
+			// It is VERY unlikely that we'll have two players, in the same round, with the same name and branch, but still, this is here.
+			// If such conflict is encountered, a random number will be appended to the email address. If this fails too, no email account will be created.
+			if(ntnet_global.does_email_exist(complete_login))
+				complete_login = "[sanitized_name][random_id(/datum/computer_file/data/email_account/, 100, 999)]@[domain]"
 
-		// If even fallback login generation failed, just don't give them an email. The chance of this happening is astronomically low.
-		if(ntnet_global.does_email_exist(complete_login))
-			to_chat(H, "You were not assigned an email address.")
-			H.mind.store_memory("You were not assigned an email address.")
-		else
-			var/datum/computer_file/data/email_account/EA = new/datum/computer_file/data/email_account()
-			EA.password = GenerateKey()
-			EA.login = 	complete_login
-			to_chat(H, "Your email account address is <b>[EA.login]</b> and the password is <b>[EA.password]</b>. This information has also been placed into your notes.")
-			H.mind.store_memory("Your email account address is [EA.login] and the password is [EA.password].")
-		// END EMAIL GENERATION
+			// If even fallback login generation failed, just don't give them an email. The chance of this happening is astronomically low.
+			if(ntnet_global.does_email_exist(complete_login))
+				to_chat(H, "You were not assigned an email address.")
+				H.mind.store_memory("You were not assigned an email address.")
+			else
+				var/datum/computer_file/data/email_account/EA = new/datum/computer_file/data/email_account()
+				EA.password = GenerateKey()
+				EA.login = 	complete_login
+				to_chat(H, "Your email account address is <b>[EA.login]</b> and the password is <b>[EA.password]</b>. This information has also been placed into your notes.")
+				H.mind.store_memory("Your email account address is [EA.login] and the password is [EA.password].")
+			// END EMAIL GENERATION
 
 		//Gives glasses to the vision impaired
 		if(H.disabilities & NEARSIGHTED)


### PR DESCRIPTION
What it says in the tin. Just set `has_email` and `has_account` to `TRUE` or `FALSE`. Still working on backpacks.