### PR TITLE
fixes SCP-049-1 being immortal

### DIFF
--- a/code/modules/mob/living/carbon/human/species/outsider/scp049_1.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/scp049_1.dm
@@ -17,3 +17,11 @@
 
 	// fists
 	unarmed_types = list(/datum/unarmed_attack/claw)
+
+	// damage overrides
+	brute_mod =      0.5                    // 50% physical damage
+	burn_mod =       0.5                    // 50% burn damage
+	oxy_mod =        0.0                    // No oxygen damage
+	toxins_mod =     0.0                    // No toxin damage
+	radiation_mod =  0.0                    // No radiation damage
+	flash_mod =      0.0                    // Unflashable

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -8,12 +8,9 @@
 
 /obj/item/organ/external/take_damage(brute, burn, damage_flags, used_weapon = null)
 
-	if (isscp049_1(loc) && organ_tag != BP_HEAD)
-		brute = 0 
-		burn = 0
-
 	brute = round(brute * brute_mod, 0.1)
 	burn = round(burn * burn_mod, 0.1)
+
 	if((brute <= 0) && (burn <= 0))
 		return 0
 

--- a/html/changelogs/scp0491-immortality.yml
+++ b/html/changelogs/scp0491-immortality.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Memeopolis
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed SCP-049-1 being immortal."


### PR DESCRIPTION
SCP-049-1 now has the same damage variables as SCP-049, and is no longer immortal.