### PR TITLE
fixes more GC lag & hard deletes

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -22,9 +22,12 @@
 	var/item_state = null // Used to specify the item state for the on-mob overlays.
 
 /atom/movable/Destroy()
-
-	for(var/AM in src)
-		qdel(AM)
+	
+	// not deleting all of these at once may prevent hard-deletes
+	var/delay = 10
+	for(var/AM in contents)
+		qdel_after(AM, delay)
+		delay += 10
 
 	forceMove(null)
 	

--- a/code/game/images.dm
+++ b/code/game/images.dm
@@ -1,2 +1,3 @@
 /image/Destroy()
-	return ..()
+	..()
+	return QDEL_HINT_IWILLGC

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -4,9 +4,12 @@
 /var/list/view_variables_no_assoc = list("verbs", "contents","screen","images")
 
 // Acceptable 'in world', as VV would be incredibly hampered otherwise
-/client/proc/debug_variables2(var/datum/D in list(GLOB)+world.contents)
+/client/proc/debug_variables2()
 	set category = "Debug"
 	set name = "View Variables 2.0"
+	if ((input(src, "Debug GLOB?") in list("Yes", "No")) == "Yes")
+		return debug_variables(GLOB)
+	var/datum/D = input(src, "Debug what variable?") in world
 	return debug_variables(D)
 
 /client/proc/debug_variables(var/datum/D in world)


### PR DESCRIPTION
Using VV 2.0 caused a huge list to be created and garbage collected, causing immense GC usage. I fixed this by adding a separate prompt to debug GLOB. Also implemented some measures that limit hard deletes of images/anything in mob.contents.