### PR TITLE
Default lighting color shift, evac lighting, flickering lightbulbs

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2551,6 +2551,7 @@
 #include "maps\random_ruins\space_ruins\space_ruins.dm"
 #include "maps\site53\site53.dm"
 #include "maps\site53\site53_define.dm"
+#include "maps\site53\site53shuttles.dm"
 #include "maps\~mapsystem\map_preferences.dm"
 #include "maps\~mapsystem\map_ranks.dm"
 #include "maps\~mapsystem\maps.dm"

--- a/code/controllers/evacuation/evacuation.dm
+++ b/code/controllers/evacuation/evacuation.dm
@@ -87,8 +87,9 @@ var/datum/evacuation_controller/evacuation_controller
 
 	if(emergency_evacuation)
 		for(var/area in GLOB.areas)
+			var/area/A = area
+			A.set_emergency_lighting(1)
 			if(istype(area, /area/hallway))
-				var/area/A = area
 				A.readyalert()
 		if(!skip_announce)
 			GLOB.using_map.emergency_shuttle_called_announcement()
@@ -116,8 +117,9 @@ var/datum/evacuation_controller/evacuation_controller
 	if(emergency_evacuation)
 		evac_recalled.Announce(GLOB.using_map.emergency_shuttle_recall_message)
 		for(var/area in GLOB.areas)
+			var/area/A = area
+			A.set_emergency_lighting(0)
 			if(istype(area, /area/hallway))
-				var/area/A = area
 				A.readyreset()
 		emergency_evacuation = 0
 	else


### PR DESCRIPTION
Makes standard lighting slightly yellower and more eerie.

Adds the defective flag to lights, defective lights will occasionally flicker. To make a light defective as admin, call the `cause_defect` proc on it (no params). Call the `fix_defect` on it to fix it.

![flickery](https://user-images.githubusercontent.com/37093159/47124200-903dcd80-d231-11e8-9856-214d3cdc3a2a.gif)

Evac lights are orange and scary.

![evac](https://user-images.githubusercontent.com/37093159/47124195-8ae08300-d231-11e8-9ca2-f4ca7a356e5e.gif)


